### PR TITLE
Fix/dht interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "coverage": "aegir coverage"
   },
   "devDependencies": {
-    "aegir": "^15.0.1",
+    "aegir": "^15.1.0",
     "chai": "^4.1.2",
     "cids": "~0.5.3",
     "go-ipfs-dep": "~0.4.16",
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "async": "^2.6.0",
-    "ipfs-api": "^22.2.4",
+    "ipfs-api": "^24.0.1",
     "multiaddr": "^4.0.0",
     "peer-id": "~0.11.0",
     "peer-info": "~0.14.1"

--- a/src/index.js
+++ b/src/index.js
@@ -59,10 +59,16 @@ class DelegatedContentRouting {
    * - does not support the `timeout` parameter, as this is specific to the delegate node.
    *
    * @param {CID} key
+   * @param {number} _timeout This is ignored and is only present to comply with the dht interface
    * @param {function(Error, Array<PeerInfo>)} callback
    * @returns {void}
    */
-  findProviders (key, callback) {
+  findProviders (key, _timeout, callback) {
+    if (typeof _timeout == 'function') {
+      callback = _timeout
+      _timeout = null
+    }
+
     this.dht.findprovs(key.toBaseEncodedString(), (err, results) => {
       if (err) {
         return callback(err)

--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,7 @@ class DelegatedContentRouting {
    * @returns {void}
    */
   findProviders (key, _timeout, callback) {
-    if (typeof _timeout == 'function') {
+    if (typeof _timeout === 'function') {
       callback = _timeout
       _timeout = null
     }


### PR DESCRIPTION
Currently findProviders doesn't comply with the dht interface as it doesn't have the timeout parameter. This PR adds the timeout, even though it is ignored (which is mentioned in the jsdocs).  

The reason for this is that it makes it significantly easier to run multiple content routing modules, which we will allow in js-libp2p, when the function signatures match.

For example in the update to js-libp2p, https://github.com/libp2p/js-libp2p/pull/242/files#diff-b0f6b211af5c98be53893311b36c8d1fR30, we will allow for multiple content routing modules along with the dht. This change makes that logic much simpler.