### PR TITLE
fix: better support peer ids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ bower_components
 # Compiled binary addons (http://nodejs.org/api/addons.html)
 build/Release
 
+# Build Documentation
+docs
+
 # Dependency directories
 node_modules/
 jspm_packages/

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const PeerInfo = require('peer-info')
+const PeerID = require('peer-id')
 const dht = require('ipfs-api/src/dht')
 const swarm = require('ipfs-api/src/swarm')
 const refs = require('ipfs-api/src/refs')
@@ -80,7 +81,9 @@ class DelegatedContentRouting {
         .filter((res) => Boolean(res.Responses))
         .forEach((res) => {
           res.Responses.forEach((raw) => {
-            const info = new PeerInfo(raw.ID)
+            const info = new PeerInfo(
+              PeerID.createFromB58String(raw.ID)
+            )
             if (raw.Addrs) {
               raw.Addrs.forEach((addr) => info.multiaddrs.add(addr))
             }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -139,7 +139,7 @@ describe('DelegatedContentRouting', function () {
           // We should get our local node and the bootstrap node as providers.
           // The delegate node is not included, because it is handling the requests
           expect(providers).to.have.length(2)
-          expect(providers.map((p) => p.id)).to.have.members([
+          expect(providers.map((p) => p.id.toB58String())).to.have.members([
             bootstrapId.id,
             selfId.toB58String()
           ])


### PR DESCRIPTION
After working on an example I ran into some inconsistency issues with peer ids not being proper ids.

This PR ensures that the PeerInfo returned from findProviders contains an actual PeerID.