### PR TITLE
fix: limit concurrent HTTP requests  (backport for 0.2.x)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "async": "^2.6.2",
     "ipfs-http-client": "^33.0.2",
     "multiaddr": "^6.1.0",
+    "p-queue": "^6.1.0",
     "peer-id": "^0.12.2",
     "peer-info": "^0.15.1"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -85,8 +85,8 @@ class DelegatedContentRouting {
     this._httpQueue.add(() =>
       this.dht.findProvs(key.toString(), {
         timeout: `${options.maxTimeout}ms` // The api requires specification of the time unit (s/ms)
-      }, callback)
-    ).catch(callback)
+      })
+    ).then(res => callback(null, res), callback)
   }
 
   /**
@@ -102,7 +102,7 @@ class DelegatedContentRouting {
    */
   provide (key, callback) {
     this._httpQueueRefs.add(() =>
-      this.refs(key.toString(), { recursive: false }, (err, res) => callback(err))
+      this.refs(key.toString(), { recursive: false }, (err) => callback(err))
     ).catch(callback)
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -102,8 +102,8 @@ class DelegatedContentRouting {
    */
   provide (key, callback) {
     this._httpQueueRefs.add(() =>
-      this.refs(key.toString(), { recursive: false }, (err) => callback(err))
-    ).catch(callback)
+      this.refs(key.toString(), { recursive: false })
+    ).then(() => callback(), callback)
   }
 }
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -88,14 +88,14 @@ describe('DelegatedContentRouting', function () {
       expect(() => new DelegatedContentRouting()).to.throw()
     })
 
-    it('should default to https://ipfs.io as the delegate', () => {
+    it('should default to https://node0.delegate.ipfs.io as the delegate', () => {
       const router = new DelegatedContentRouting(selfId)
 
       expect(router.api).to.include({
         'api-path': '/api/v0/',
         protocol: 'https',
         port: 443,
-        host: 'ipfs.io'
+        host: 'node0.delegate.ipfs.io'
       })
     })
 


### PR DESCRIPTION
This is a backport of the fix from https://github.com/libp2p/js-libp2p-delegated-content-routing/pull/16 that works with 0.2.x.

The goal is to include the fix in latest js-ipfs release (without waiting for async/await changes to be propagated to js-libp2p)

cc @alanshaw @jacobheun 
