### PR TITLE
chore: rename timeout option

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,19 +18,19 @@
     "coverage": "aegir coverage"
   },
   "devDependencies": {
-    "aegir": "^19.0.5",
+    "aegir": "^20.4.1",
     "async-iterator-all": "^1.0.0",
     "chai": "^4.2.0",
     "cids": "^0.7.1",
-    "go-ipfs-dep": "~0.4.17",
-    "ipfsd-ctl": "~0.44.1",
-    "peer-id": "~0.13.1"
+    "go-ipfs-dep": "~0.4.22",
+    "ipfsd-ctl": "~0.47.4",
+    "peer-id": "~0.13.5"
   },
   "dependencies": {
     "debug": "^4.1.1",
-    "ipfs-http-client": "^33.1.0",
-    "multiaddr": "^6.1.0",
-    "p-queue": "^6.1.0"
+    "ipfs-http-client": "^40.0.1",
+    "multiaddr": "^7.2.1",
+    "p-queue": "^6.2.1"
   },
   "contributors": [
     "Alan Shaw <alan.shaw@protocol.ai>",

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -75,7 +75,7 @@ describe('DelegatedContentRouting', function () {
       const router = new DelegatedContentRouting(selfId)
 
       expect(router.api).to.include({
-        'api-path': '/api/v0/',
+        'api-path': '/api/v0',
         protocol: 'https',
         port: 443,
         host: 'node0.delegate.ipfs.io'
@@ -88,7 +88,7 @@ describe('DelegatedContentRouting', function () {
       })
 
       expect(router.api).to.include({
-        'api-path': '/api/v0/',
+        'api-path': '/api/v0',
         protocol: 'https',
         port: 443,
         host: 'other.ipfs.io'
@@ -97,7 +97,7 @@ describe('DelegatedContentRouting', function () {
 
     it('should allow for overriding the api', () => {
       const api = {
-        'api-path': '/api/v1/',
+        'api-path': '/api/v1',
         protocol: 'http',
         port: 8000,
         host: 'localhost'
@@ -132,7 +132,7 @@ describe('DelegatedContentRouting', function () {
       expect(providers.map((p) => p.id.toB58String())).to.include(selfId.toB58String(), 'Did not include self node')
     })
 
-    it('should be able to specify a maxTimeout', async () => {
+    it('should be able to specify a timeout', async () => {
       const opts = delegateNode.apiAddr.toOptions()
       const routing = new DelegatedContentRouting(selfId, {
         protocol: 'http',
@@ -141,7 +141,7 @@ describe('DelegatedContentRouting', function () {
       })
 
       const cid = new CID('QmS4ustL54uo8FzR9455qaxZwuMiUhyvMcX9Ba8nUH4uVv')
-      const providers = await all(routing.findProviders(cid, { maxTimeout: 5e3 }))
+      const providers = await all(routing.findProviders(cid, { timeout: 5e3 }))
 
       expect(providers.map((p) => p.id.toB58String())).to.include(bootstrapId.id, 'Did not include bootstrap node')
     })
@@ -149,18 +149,15 @@ describe('DelegatedContentRouting', function () {
 
   describe('provide', () => {
     it('should be able to register as a content provider to the delegate node', async () => {
-      let contentRouter
-      let cid
-
       const opts = delegateNode.apiAddr.toOptions()
-      contentRouter = new DelegatedContentRouting(selfId, {
+      const contentRouter = new DelegatedContentRouting(selfId, {
         protocol: 'http',
         port: opts.port,
         host: opts.host
       })
 
       const res = await selfNode.api.add(Buffer.from(`hello-${Math.random()}`))
-      cid = new CID(res[0].hash)
+      const cid = new CID(res[0].hash)
       await contentRouter.provide(cid)
       const providers = await delegateNode.api.dht.findProvs(cid.toBaseEncodedString())
 


### PR DESCRIPTION
This PR renames timeout option to be consistent with the `libp2p-kad-dht` implementation, in order to both be used in the `libp2p` routers.

Other than that, dependencies were updated

BREAKING CHANGE: maxTimeout option renamed to timeout