### PR TITLE
fix: async it refs

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   },
   "devDependencies": {
     "aegir": "^20.4.1",
-    "async-iterator-all": "^1.0.0",
     "chai": "^4.2.0",
     "cids": "^0.7.1",
     "go-ipfs-dep": "~0.4.22",
@@ -27,6 +26,7 @@
     "peer-id": "~0.13.5"
   },
   "dependencies": {
+    "async-iterator-all": "^1.0.0",
     "debug": "^4.1.1",
     "ipfs-http-client": "^40.0.1",
     "multiaddr": "^7.2.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,13 @@
 'use strict'
 
+const debug = require('debug')
+
 const dht = require('ipfs-http-client/src/dht')
 const refs = require('ipfs-http-client/src/refs')
 const getEndpointConfig = require('ipfs-http-client/src/get-endpoint-config')
+
 const { default: PQueue } = require('p-queue')
-const debug = require('debug')
+const all = require('async-iterator-all')
 
 const log = debug('libp2p-delegated-content-routing')
 log.error = debug('libp2p-delegated-content-routing:error')
@@ -90,7 +93,7 @@ class DelegatedContentRouting {
     const keyString = key.toBaseEncodedString()
     log('provide starts: ' + keyString)
     await this._httpQueueRefs.add(() =>
-      this.refs(keyString, { recursive: false })
+      all(this.refs(keyString, { recursive: false }))
     )
     log('provide finished: ' + keyString)
   }

--- a/src/index.js
+++ b/src/index.js
@@ -92,10 +92,10 @@ class DelegatedContentRouting {
   async provide (key) {
     const keyString = key.toBaseEncodedString()
     log('provide starts: ' + keyString)
-    await this._httpQueueRefs.add(() =>
+    const results = await this._httpQueueRefs.add(() =>
       all(this.refs(keyString, { recursive: false }))
     )
-    log('provide finished: ' + keyString)
+    log('provide finished: ', keyString, results)
   }
 }
 


### PR DESCRIPTION
In the new version of `ipfs-http-client` the refs is an async iterator instead of a promise.:

https://github.com/ipfs/js-ipfs-http-client/blob/master/src/refs/index.js#L12