### PR TITLE
chore: use it-all

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "peer-id": "~0.13.5"
   },
   "dependencies": {
-    "async-iterator-all": "^1.0.0",
+    "it-all": "^1.0.0",
     "debug": "^4.1.1",
     "ipfs-http-client": "^40.0.1",
     "multiaddr": "^7.2.1",

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ const refs = require('ipfs-http-client/src/refs')
 const getEndpointConfig = require('ipfs-http-client/src/get-endpoint-config')
 
 const { default: PQueue } = require('p-queue')
-const all = require('async-iterator-all')
+const all = require('it-all')
 
 const log = debug('libp2p-delegated-content-routing')
 log.error = debug('libp2p-delegated-content-routing:error')

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -5,7 +5,7 @@ const expect = require('chai').expect
 const IPFSFactory = require('ipfsd-ctl')
 const CID = require('cids')
 const PeerId = require('peer-id')
-const all = require('async-iterator-all')
+const all = require('it-all')
 const factory = IPFSFactory.create({
   type: 'go'
 })


### PR DESCRIPTION
Use `it-all` dependency instead of `async-iterator-all`