### PR TITLE
chore: remove peer-info from api

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ const routing = new DelegatedContentRouing(peerId, {
 })
 const cid = new CID('QmS4ustL54uo8FzR9455qaxZwuMiUhyvMcX9Ba8nUH4uVv')
 
-for await (const peerInfo of routing.findProviders(cid)) {
-  console.log('found peer', peerInfo)
+for await (const { id, addrs } of routing.findProviders(cid)) {
+  console.log('found peer', id, addrs)
 }
 
 await routing.provide(cid)

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ const routing = new DelegatedContentRouing(peerId, {
 })
 const cid = new CID('QmS4ustL54uo8FzR9455qaxZwuMiUhyvMcX9Ba8nUH4uVv')
 
-for await (const { id, addrs } of routing.findProviders(cid)) {
-  console.log('found peer', id, addrs)
+for await (const { id, multiaddrs } of routing.findProviders(cid)) {
+  console.log('found peer', id, multiaddrs)
 }
 
 await routing.provide(cid)

--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
     "it-all": "^1.0.0",
     "multiaddr": "^7.4.3",
     "p-defer": "^3.0.0",
-    "p-queue": "^6.3.0",
-    "peer-info": "^0.17.5"
+    "p-queue": "^6.2.1"
   },
   "contributors": [
     "Jacob Heun <jacobheun@gmail.com>",

--- a/src/index.js
+++ b/src/index.js
@@ -62,7 +62,7 @@ class DelegatedContentRouting {
    * @param {object} options
    * @param {number} options.timeout How long the query can take. Defaults to 30 seconds
    * @param {number} options.numProviders How many providers to find, defaults to 20
-   * @returns {AsyncIterable<{ id: PeerId, addrs: Multiaddr[] }>}
+   * @returns {AsyncIterable<{ id: PeerId, multiaddrs: Multiaddr[] }>}
    */
   async * findProviders (key, options = {}) {
     const keyString = `${key}`
@@ -86,7 +86,7 @@ class DelegatedContentRouting {
       })) {
         yield {
           id: PeerId.createFromCID(id),
-          addrs
+          multiaddrs: addrs
         }
       }
     } catch (err) {

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,6 @@
 
 const debug = require('debug')
 const PeerId = require('peer-id')
-const PeerInfo = require('peer-info')
 const createFindProvs = require('ipfs-http-client/src/dht/find-provs')
 const createRefs = require('ipfs-http-client/src/refs')
 
@@ -63,7 +62,7 @@ class DelegatedContentRouting {
    * @param {object} options
    * @param {number} options.timeout How long the query can take. Defaults to 30 seconds
    * @param {number} options.numProviders How many providers to find, defaults to 20
-   * @returns {AsyncIterable<PeerInfo>}
+   * @returns {AsyncIterable<{ id: PeerId, addrs: Multiaddr[] }>}
    */
   async * findProviders (key, options = {}) {
     const keyString = `${key}`
@@ -85,9 +84,10 @@ class DelegatedContentRouting {
         numProviders: options.numProviders,
         timeout: options.timeout
       })) {
-        const peerInfo = new PeerInfo(PeerId.createFromCID(id))
-        addrs.forEach(addr => peerInfo.multiaddrs.add(addr))
-        yield peerInfo
+        yield {
+          id: PeerId.createFromCID(id),
+          addrs
+        }
       }
     } catch (err) {
       log.error('findProviders errored:', err)


### PR DESCRIPTION
In the context of deprecating `peer-info` as described on [libp2p/js-libp2p#589](https://github.com/libp2p/js-libp2p/issues/589), this PR removes the `peer-info` from being returned in the API, in favour of returning `{ id, addrs }` in the same way as [ipfs](https://github.com/ipfs/js-ipfs/blob/447b44d1b64714f5ed0cafba166ad0a4dbbb587c/packages/ipfs/src/core/components/dht.js#L61) does.


BREAKING CHANGE: findProviders returns id and addrs properties instead of peer-info instance

Needs:

- [x]  [libp2p/js-libp2p-interfaces#43](https://github.com/libp2p/js-libp2p-interfaces/pull/43)