### PR TITLE
chore: make ipfs-http-client a peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ Requires access to `/api/v0/dht/findprovs` and `/api/v0/refs` HTTP API endpoints
 
 [Jacob Heun](https://github.com/jacobheun)
 
+## Requirements
+
+`libp2p-delegated-content-routing` leverages the `ipfs-http-client` library and requires it as a peer dependency, as such, both must be installed in order for this module to work properly.
+
+```sh
+npm install ipfs-http-client libp2p-delegated-content-routing
+```
+
 ## Example
 
 ```js

--- a/package.json
+++ b/package.json
@@ -22,15 +22,18 @@
     "chai": "^4.2.0",
     "cids": "^0.8.0",
     "go-ipfs-dep": "0.4.23-3",
+    "ipfs-http-client": "^44.0.0",
     "ipfs-utils": "^2.2.0",
     "ipfsd-ctl": "^4.0.1",
     "it-drain": "^1.0.0",
     "it-last": "^1.0.1",
     "peer-id": "^0.13.11"
   },
+  "peerDependencies": {
+    "ipfs-http-client": "^44.0.0"
+  },
   "dependencies": {
     "debug": "^4.1.1",
-    "ipfs-http-client": "^44.0.0",
     "it-all": "^1.0.0",
     "multiaddr": "^7.4.3",
     "p-defer": "^3.0.0",


### PR DESCRIPTION
BREAKING CHANGE: The ipfs-http-client must now be installed
as a peer dependency. It is no longer included as a dependency
of this module.

The reason the http-client should be a peerDependency and
not a dependency is that its API requires knowledge of the
http-client (we pass in the api endpoint details).

Supersedes https://github.com/libp2p/js-libp2p-delegated-content-routing/pull/31