### PR TITLE
fix: replace node buffers with uint8arrays

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -13,7 +13,7 @@ module.exports = {
         }, {
           type: 'go',
           ipfsHttpModule: require('ipfs-http-client'),
-          ipfsBin: require('go-ipfs-dep').path(),
+          ipfsBin: require('go-ipfs').path(),
           test: true
         })
 

--- a/package.json
+++ b/package.json
@@ -18,24 +18,22 @@
     "coverage": "aegir coverage"
   },
   "devDependencies": {
-    "aegir": "^21.8.1",
-    "chai": "^4.2.0",
-    "cids": "^0.8.0",
-    "go-ipfs-dep": "0.4.23-3",
-    "ipfs-http-client": "^44.0.0",
+    "aegir": "^25.0.0",
+    "go-ipfs": "^0.6.0",
+    "ipfs-http-client": "^45.0.0",
     "ipfs-utils": "^2.2.0",
-    "ipfsd-ctl": "^4.0.1",
+    "ipfsd-ctl": "^5.0.0",
     "it-drain": "^1.0.0",
-    "it-last": "^1.0.1",
-    "peer-id": "^0.13.11"
+    "peer-id": "^0.14.0",
+    "uint8arrays": "^1.1.0"
   },
   "peerDependencies": {
-    "ipfs-http-client": "^44.0.0"
+    "ipfs-http-client": "^45.0.0"
   },
   "dependencies": {
     "debug": "^4.1.1",
     "it-all": "^1.0.0",
-    "multiaddr": "^7.4.3",
+    "multiaddr": "^8.0.0",
     "p-defer": "^3.0.0",
     "p-queue": "^6.2.1"
   },

--- a/package.json
+++ b/package.json
@@ -18,17 +18,17 @@
     "coverage": "aegir coverage"
   },
   "devDependencies": {
-    "aegir": "^25.0.0",
+    "aegir": "^25.1.0",
     "go-ipfs": "^0.6.0",
-    "ipfs-http-client": "^45.0.0",
-    "ipfs-utils": "^2.2.0",
+    "ipfs-http-client": "^46.0.0",
+    "ipfs-utils": "^2.4.0",
     "ipfsd-ctl": "^5.0.0",
     "it-drain": "^1.0.0",
     "peer-id": "^0.14.0",
     "uint8arrays": "^1.1.0"
   },
   "peerDependencies": {
-    "ipfs-http-client": "^45.0.0"
+    "ipfs-http-client": "^46.0.0"
   },
   "dependencies": {
     "debug": "^4.1.1",

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -111,11 +111,18 @@ describe('DelegatedContentRouting', function () {
   })
 
   describe('findProviders', () => {
-    const cid = new CID('QmS4ustL54uo8FzR9455qaxZwuMiUhyvMcX9Ba8nUH4uVv')
+    const data = uint8ArrayFromString('some data')
+    const cid = new CID('QmVv4Wz46JaZJeH5PMV4LGbRiiMKEmszPYY3g6fjGnVXBS') // 'some data'
 
     before('register providers', async () => {
-      await drain(bootstrapNode.api.dht.provide(cid))
-      await drain(selfNode.api.dht.provide(cid))
+      await Promise.all([
+        bootstrapNode.api.add(data),
+        selfNode.api.add(data)
+      ])
+      await Promise.all([
+        drain(bootstrapNode.api.dht.provide(cid)),
+        drain(selfNode.api.dht.provide(cid))
+      ])
     })
 
     it('should be able to find providers through the delegate node', async function () {
@@ -142,7 +149,6 @@ describe('DelegatedContentRouting', function () {
         host: opts.host
       })
 
-      const cid = new CID('QmS4ustL54uo8FzR9455qaxZwuMiUhyvMcX9Ba8nUH4uVv')
       const providers = await all(routing.findProviders(cid, { numProviders: 2, timeout: 5e3 }))
 
       expect(providers.map((p) => p.id.toB58String())).to.include(bootstrapId.id, 'Did not include bootstrap node')

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,18 +1,18 @@
 /* eslint-env mocha */
 'use strict'
 
-const expect = require('chai').expect
+const { expect } = require('aegir/utils/chai')
 const { createFactory } = require('ipfsd-ctl')
-const CID = require('cids')
+const { CID } = require('ipfs-http-client')
 const PeerId = require('peer-id')
 const all = require('it-all')
-const last = require('it-last')
 const drain = require('it-drain')
 const { isNode } = require('ipfs-utils/src/env')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 const factory = createFactory({
   type: 'go',
   ipfsHttpModule: require('ipfs-http-client'),
-  ipfsBin: isNode ? require('go-ipfs-dep').path() : undefined,
+  ipfsBin: isNode ? require('go-ipfs').path() : undefined,
   test: true,
   endpoint: 'http://localhost:57483'
 })
@@ -158,7 +158,7 @@ describe('DelegatedContentRouting', function () {
         host: opts.host
       })
 
-      const { cid } = await last(selfNode.api.add(Buffer.from(`hello-${Math.random()}`)))
+      const { cid } = await selfNode.api.add(uint8ArrayFromString(`hello-${Math.random()}`))
 
       await contentRouter.provide(cid)
 


### PR DESCRIPTION
BREAKING CHANGE:

- all useage of node Buffers has been replaced with Uint8Arrays
- all deps now use Uint8Arrays instead of node Buffers