### PR TITLE
fix: accept http client instance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ stages:
   - cov
 
 node_js:
-  - '10'
-  - '12'
+  - 'lts/*'
+  - 'node'
 
 os:
   - linux

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Requires access to `/api/v0/dht/findprovs` and `/api/v0/refs` HTTP API endpoints
 
 ## Requirements
 
-`libp2p-delegated-content-routing` leverages the `ipfs-http-client` library and requires it as a peer dependency, as such, both must be installed in order for this module to work properly.
+`libp2p-delegated-content-routing` leverages the `ipfs-http-client` library and requires an instance of it as a constructor argument.
 
 ```sh
 npm install ipfs-http-client libp2p-delegated-content-routing
@@ -28,14 +28,15 @@ npm install ipfs-http-client libp2p-delegated-content-routing
 
 ```js
 const DelegatedContentRouting = require('libp2p-delegated-content-routing')
+const ipfsHttpClient = require('ipfs-http-client')
 
 // default is to use ipfs.io
-const routing = new DelegatedContentRouing(peerId, {
+const routing = new DelegatedContentRouing(peerId, ipfsHttpClient({
   // use default api settings
   protocol: 'https',
   port: 443,
   host: 'ipfs.io'
-})
+}))
 const cid = new CID('QmS4ustL54uo8FzR9455qaxZwuMiUhyvMcX9Ba8nUH4uVv')
 
 for await (const { id, multiaddrs } of routing.findProviders(cid)) {

--- a/package.json
+++ b/package.json
@@ -18,17 +18,14 @@
     "coverage": "aegir coverage"
   },
   "devDependencies": {
-    "aegir": "^25.1.0",
+    "aegir": "^26.0.0",
     "go-ipfs": "^0.6.0",
     "ipfs-http-client": "^46.0.0",
-    "ipfs-utils": "^2.4.0",
+    "ipfs-utils": "^3.0.0",
     "ipfsd-ctl": "^5.0.0",
     "it-drain": "^1.0.0",
     "peer-id": "^0.14.0",
     "uint8arrays": "^1.1.0"
-  },
-  "peerDependencies": {
-    "ipfs-http-client": "^46.0.0"
   },
   "dependencies": {
     "debug": "^4.1.1",
@@ -36,6 +33,9 @@
     "multiaddr": "^8.0.0",
     "p-defer": "^3.0.0",
     "p-queue": "^6.2.1"
+  },
+  "browser": {
+    "go-ipfs": false
   },
   "contributors": [
     "Jacob Heun <jacobheun@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
     "p-defer": "^3.0.0",
     "p-queue": "^6.2.1"
   },
+  "peerDependencies": {
+    "ipfs-http-client": "^46.0.0"
+  },
   "browser": {
     "go-ipfs": false
   },


### PR DESCRIPTION
Instead of the http client being a dependency of this module, accept
a pre-configured http client instance at construction time.

This resolves the weird dependency loop and means we can remove this
module from the no-hoist config in ipfs.

BREAKING CHANGE:

- An instance of ipfs http client is now a required argument