### PR TITLE
chore: update ipfs-http-client peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
     "coverage": "aegir coverage"
   },
   "devDependencies": {
-    "aegir": "^26.0.0",
-    "go-ipfs": "^0.6.0",
+    "aegir": "^28.0.2",
+    "go-ipfs": "^0.7.0",
     "ipfs-http-client": "^47.0.1",
-    "ipfs-utils": "^3.0.0",
-    "ipfsd-ctl": "^5.0.0",
+    "ipfs-utils": "^4.0.0",
+    "ipfsd-ctl": "^7.0.2",
     "it-drain": "^1.0.0",
     "peer-id": "^0.14.0",
     "uint8arrays": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "aegir": "^26.0.0",
     "go-ipfs": "^0.6.0",
-    "ipfs-http-client": "^46.0.0",
+    "ipfs-http-client": "^47.0.1",
     "ipfs-utils": "^3.0.0",
     "ipfsd-ctl": "^5.0.0",
     "it-drain": "^1.0.0",
@@ -35,7 +35,7 @@
     "p-queue": "^6.2.1"
   },
   "peerDependencies": {
-    "ipfs-http-client": "^46.0.0"
+    "ipfs-http-client": "^47.0.1"
   },
   "browser": {
     "go-ipfs": false

--- a/src/index.js
+++ b/src/index.js
@@ -61,8 +61,8 @@ class DelegatedContentRouting {
    *
    * @param {CID} key
    * @param {object} options
-   * @param {number} options.timeout How long the query can take. Defaults to 30 seconds
-   * @param {number} options.numProviders How many providers to find, defaults to 20
+   * @param {number} options.timeout - How long the query can take. Defaults to 30 seconds
+   * @param {number} options.numProviders - How many providers to find, defaults to 20
    * @returns {AsyncIterable<{ id: PeerId, multiaddrs: Multiaddr[] }>}
    */
   async * findProviders (key, options = {}) {
@@ -107,7 +107,6 @@ class DelegatedContentRouting {
    * - call refs on the delegated node, so it fetches the content
    *
    * @param {CID} key
-   * @param {function(Error)} callback
    * @returns {Promise<void>}
    */
   async provide (key) {


### PR DESCRIPTION
Fixes this sort of error:

```
npm ERR! Conflicting peer dependency: ipfs-http-client@46.1.2
npm ERR! node_modules/ipfs-http-client
npm ERR!   peer ipfs-http-client@"^46.0.0" from libp2p-delegated-content-routing@0.7.0
npm ERR!   node_modules/libp2p-delegated-content-routing
npm ERR!     libp2p-delegated-content-routing@"^0.7.0" from the root project
```