### PR TITLE
feat: allow providing non-dag-pb nodes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ os:
   - linux
   - osx
 
+before_install:
+  # modules with pre-built binaries may not have deployed versions for bleeding-edge node so this lets us fall back to building from source
+  - npm install node-pre-gyp -g
+
 script: npx nyc -s npm run test:node -- --bail
 after_success: npx nyc report --reporter=text-lcov > coverage.lcov && npx codecov
 

--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
     "ipfs-http-client": "^48.1.2",
     "ipfs-utils": "^5.0.1",
     "ipfsd-ctl": "^7.0.2",
+    "it-all": "^1.0.0",
     "it-drain": "^1.0.0",
     "peer-id": "^0.14.0",
     "uint8arrays": "^1.1.0"
   },
   "dependencies": {
     "debug": "^4.1.1",
-    "it-all": "^1.0.0",
     "multiaddr": "^8.0.0",
     "p-defer": "^3.0.0",
     "p-queue": "^6.2.1"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "debug": "^4.1.1",
+    "it-drain": "^1.0.3",
     "multiaddr": "^8.0.0",
     "p-defer": "^3.0.0",
     "p-queue": "^6.2.1"

--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,7 @@ class DelegatedContentRouting {
       await onStart.promise
 
       for await (const { id, addrs } of this._client.dht.findProvs(key, {
-        numProviders: options.numProviders || 1,
+        numProviders: options.numProviders,
         timeout: options.timeout
       })) {
         yield {

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 
 const debug = require('debug')
 const PeerId = require('peer-id')
+const drain = require('it-drain')
 
 const { default: PQueue } = require('p-queue')
 const defer = require('p-defer')
@@ -124,7 +125,7 @@ class DelegatedContentRouting {
     log(`provide starts: ${key}`)
     await this._httpQueueRefs.add(async () => {
       await this._client.block.stat(key)
-      await this._client.dht.provide(key)
+      await drain(this._client.dht.provide(key))
     })
     log(`provide finished: ${key}`)
   }

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,6 @@ const debug = require('debug')
 const PeerId = require('peer-id')
 
 const { default: PQueue } = require('p-queue')
-const all = require('it-all')
 const defer = require('p-defer')
 
 const log = debug('libp2p-delegated-content-routing')
@@ -12,6 +11,12 @@ log.error = debug('libp2p-delegated-content-routing:error')
 
 const DEFAULT_TIMEOUT = 30e3 // 30 second default
 const CONCURRENT_HTTP_REQUESTS = 4
+
+/**
+ * @typedef {import('peer-id').PeerID} PeerID
+ * @typedef {import('cids').CID} CID
+ * @typedef {import('multiaddr').Multiaddr} Multiaddr
+ */
 
 /**
  * An implementation of content routing, using a delegated peer.
@@ -40,7 +45,7 @@ class DelegatedContentRouting {
     const concurrency = { concurrency: CONCURRENT_HTTP_REQUESTS }
     this._httpQueue = new PQueue(concurrency)
     // sometimes refs requests take long time, they need separate queue
-    // to not suffocate regular bussiness
+    // to not suffocate regular business
     this._httpQueueRefs = new PQueue(Object.assign({}, concurrency, {
       concurrency: 2
     }))
@@ -59,11 +64,11 @@ class DelegatedContentRouting {
    *
    * - call `findProviders` on the delegated node.
    *
-   * @param {CID} key
-   * @param {object} options
+   * @param {CID} key - The CID to find providers for
+   * @param {object} options - Options
    * @param {number} options.timeout - How long the query can take. Defaults to 30 seconds
    * @param {number} options.numProviders - How many providers to find, defaults to 20
-   * @returns {AsyncIterable<{ id: PeerId, multiaddrs: Multiaddr[] }>}
+   * @returns {AsyncIterable<{ id: PeerId, multiaddrs: Multiaddr[] }>} - An async iterable of PeerId/Multiaddrs
    */
   async * findProviders (key, options = {}) {
     log(`findProviders starts: ${key}`)
@@ -112,7 +117,7 @@ class DelegatedContentRouting {
    * the delegate will only be able to supply the root block of the dag when asked
    * for the data by an interested peer.
    *
-   * @param {CID} key
+   * @param {CID} key - The delegate will publish a provider record for this CID
    * @returns {Promise<void>}
    */
   async provide (key) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -164,5 +164,23 @@ describe('DelegatedContentRouting', function () {
       // We are hosting the file, validate we're the provider
       expect(providers.map((p) => p.id)).to.include(selfId.toB58String(), 'Did not include self node')
     })
+
+    it('should provide non-dag-pb nodes via the delegate node', async () => {
+      const opts = delegateNode.apiAddr.toOptions()
+      const contentRouter = new DelegatedContentRouting(selfId, ipfsHttpClient({
+        protocol: 'http',
+        port: opts.port,
+        host: opts.host
+      }))
+
+      const cid = await selfNode.api.dag.put(`hello-${Math.random()}`, { format: 'dag-cbor', hashAlg: 'sha2-256' })
+
+      await contentRouter.provide(cid)
+
+      const providers = await all(delegateNode.api.dht.findProvs(cid, { numProviders: 2 }))
+
+      // We are hosting the file, validate we're the provider
+      expect(providers.map((p) => p.id)).to.include(selfId.toB58String(), 'Did not include self node')
+    })
   })
 })


### PR DESCRIPTION
The http endpoint we send the CID to be provided only understands
dag-pb nodes.

Change the endpoints from a non-recursive `ipfs refs` call to a
`ipfs block stat` instead as it does not try to interperet the data.

N.b. only the passed CID will be provided, not any children but since
the original call was a non-recursive `ipfs refs` the behaviour should
be the same.

Also expands the explanation of how the provide happens and adds the
number of found providers to the logging output to make debugging things
a little easier.