### PR TITLE
chore: remove peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,9 +35,6 @@
     "p-defer": "^3.0.0",
     "p-queue": "^6.2.1"
   },
-  "peerDependencies": {
-    "ipfs-http-client": "*"
-  },
   "browser": {
     "go-ipfs": false
   },


### PR DESCRIPTION
We added ipfs-http-client as a peer dep to signal to the user
that they should add the modules they depend on as deps of their project.

Starting with npm7 all peer deps get installed automatically which
defeats the purpose of our use of peer deps, so let's remove them.