### PR TITLE
chore: Make peer-id a normal dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "ipfsd-ctl": "^10.0.5",
     "it-all": "^1.0.0",
     "it-drain": "^1.0.0",
-    "peer-id": "^0.16.0",
     "uint8arrays": "^3.0.0"
   },
   "dependencies": {
@@ -34,7 +33,8 @@
     "it-drain": "^1.0.3",
     "multiaddr": "^10.0.0",
     "p-defer": "^3.0.0",
-    "p-queue": "^6.2.1"
+    "p-queue": "^6.2.1",
+    "peer-id": "^0.16.0"
   },
   "browser": {
     "go-ipfs": false


### PR DESCRIPTION
[Apparently](https://github.com/libp2p/js-libp2p-delegated-content-routing/blob/master/src/index.js#L4), `peer-id` is required for normal operations. Move it from `devDependencies` to `dependencies` section.