### PR TITLE
fix!: remove @libp2p/components

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # @libp2p/delegated-content-routing <!-- omit in toc -->
 
 [![libp2p.io](https://img.shields.io/badge/project-libp2p-yellow.svg?style=flat-square)](http://libp2p.io/)
-[![IRC](https://img.shields.io/badge/freenode-%23libp2p-yellow.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23libp2p)
 [![Discuss](https://img.shields.io/discourse/https/discuss.libp2p.io/posts.svg?style=flat-square)](https://discuss.libp2p.io)
 [![codecov](https://img.shields.io/codecov/c/github/libp2p/js-libp2p-delegated-content-routing.svg?style=flat-square)](https://codecov.io/gh/libp2p/js-libp2p-delegated-content-routing)
-[![CI](https://img.shields.io/github/workflow/status/libp2p/js-libp2p-interfaces/test%20&%20maybe%20release/master?style=flat-square)](https://github.com/libp2p/js-libp2p-delegated-content-routing/actions/workflows/js-test-and-release.yml)
+[![CI](https://img.shields.io/github/workflow/status/libp2p/js-libp2p-delegated-content-routing/test%20&%20maybe%20release/master?style=flat-square)](https://github.com/libp2p/js-libp2p-delegated-content-routing/actions/workflows/js-test-and-release.yml)
 
 > Leverage other peers in the libp2p network to perform Content Routing calls.
 
@@ -37,24 +36,29 @@ npm install ipfs-http-client @libp2p/delegated-content-routing
 ## Example
 
 ```js
-import { DelegatedContentRouting } from '@libp2p/delegated-content-routing'
-import ipfsHttpClient from 'ipfs-http-client'
+import { createLibp2p } from 'libp2p'
+import { delegatedContentRouting } from '@libp2p/delegated-content-routing'
+import { create as createIpfsHttpClient } from 'ipfs-http-client')
 
 // default is to use ipfs.io
-const routing = new DelegatedContentRouting(peerId, ipfsHttpClient.create({
+const client = createIpfsHttpClient({
   // use default api settings
   protocol: 'https',
   port: 443,
-  host: 'node0.delegate.ipfs.io' // In production you should setup your own delegates
-}))
-const cid = new CID('QmS4ustL54uo8FzR9455qaxZwuMiUhyvMcX9Ba8nUH4uVv')
+  host: 'node0.delegate.ipfs.io'
+})
 
-for await (const { id, multiaddrs } of routing.findProviders(cid)) {
-  console.log('found peer', id, multiaddrs)
+const node = await createLibp2p({
+  peerRouting: [
+    delegatedContentRouting(client)
+  ]
+  //.. other config
+})
+await node.start()
+
+for await (const provider of node.contentRouting.findProviders('cid')) {
+  console.log('provider', provider)
 }
-
-await routing.provide(cid)
-console.log('providing %s', cid.toBaseEncodedString())
 ```
 
 ## License

--- a/package.json
+++ b/package.json
@@ -151,15 +151,13 @@
     "aegir": "^37.5.3",
     "go-ipfs": "^0.16.0",
     "ipfs-core-types": "^0.12.0",
+    "ipfs-http-client": "^58.0.0",
     "ipfsd-ctl": "^12.0.2",
     "it-all": "^1.0.6",
     "it-drain": "^1.0.5",
     "timeout-abort-controller": "^3.0.0",
     "uint8arrays": "^4.0.2",
     "wherearewe": "^2.0.1"
-  },
-  "peerDependencies": {
-    "ipfs-http-client": "^58.0.0"
   },
   "browser": {
     "go-ipfs": false

--- a/package.json
+++ b/package.json
@@ -143,18 +143,20 @@
     "any-signal": "^3.0.1",
     "err-code": "^3.0.1",
     "it-drain": "^1.0.5",
+    "multiformats": "^10.0.0",
     "p-defer": "^4.0.0",
     "p-queue": "^7.2.0"
   },
   "devDependencies": {
     "aegir": "^37.5.3",
-    "go-ipfs": "^0.15.0",
+    "go-ipfs": "^0.16.0",
     "ipfs-core-types": "^0.12.0",
     "ipfs-http-client": "^58.0.0",
     "ipfsd-ctl": "^12.0.2",
     "it-all": "^1.0.6",
     "it-drain": "^1.0.5",
-    "uint8arrays": "^3.0.0",
+    "timeout-abort-controller": "^3.0.0",
+    "uint8arrays": "^4.0.2",
     "wherearewe": "^2.0.1"
   },
   "browser": {

--- a/package.json
+++ b/package.json
@@ -151,13 +151,15 @@
     "aegir": "^37.5.3",
     "go-ipfs": "^0.16.0",
     "ipfs-core-types": "^0.12.0",
-    "ipfs-http-client": "^58.0.0",
     "ipfsd-ctl": "^12.0.2",
     "it-all": "^1.0.6",
     "it-drain": "^1.0.5",
     "timeout-abort-controller": "^3.0.0",
     "uint8arrays": "^4.0.2",
     "wherearewe": "^2.0.1"
+  },
+  "peerDependencies": {
+    "ipfs-http-client": "^58.0.0"
   },
   "browser": {
     "go-ipfs": false

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,10 +124,10 @@ export interface Delegate {
   }
 
   dht: {
-    findProvs: (cid: CID, options?: AbortOptions) => AsyncIterable<QueryEvent>
-    provide: (cid: CID, options?: DHTProvideOptions) => AsyncIterable<QueryEvent>
-    put: (key: string | Uint8Array, value: Uint8Array, options?: AbortOptions) => AsyncIterable<QueryEvent>
-    get: (key: string | Uint8Array, options?: AbortOptions) => AsyncIterable<QueryEvent>
+    findProvs: (cid: CID, options?: HTTPClientExtraOptions & AbortOptions) => AsyncIterable<QueryEvent>
+    provide: (cid: CID, options?: HTTPClientExtraOptions & DHTProvideOptions) => AsyncIterable<QueryEvent>
+    put: (key: string | Uint8Array, value: Uint8Array, options?: HTTPClientExtraOptions & AbortOptions) => AsyncIterable<QueryEvent>
+    get: (key: string | Uint8Array, options?: HTTPClientExtraOptions & AbortOptions) => AsyncIterable<QueryEvent>
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,14 +13,14 @@ import type { PeerId } from '@libp2p/interface-peer-id'
 
 const log = logger('libp2p:delegated-content-routing')
 
+const DEFAULT_TIMEOUT = 30e3 // 30 second default
+const CONCURRENT_HTTP_REQUESTS = 4
+const CONCURRENT_HTTP_REFS_REQUESTS = 2
+
 export interface HTTPClientExtraOptions {
   headers?: Record<string, string>
   searchParams?: URLSearchParams
 }
-
-const DEFAULT_TIMEOUT = 30e3 // 30 second default
-const CONCURRENT_HTTP_REQUESTS = 4
-const CONCURRENT_HTTP_REFS_REQUESTS = 2
 
 export enum EventTypes {
   SENDING_QUERY = 0,
@@ -36,7 +36,7 @@ export enum EventTypes {
 /**
  * The types of messages set/received during DHT queries
  */
- export enum MessageType {
+export enum MessageType {
   PUT_VALUE = 0,
   GET_VALUE,
   ADD_PROVIDER,
@@ -124,7 +124,7 @@ export interface Delegate {
   }
 
   dht: {
-    findProvs: (cid: CID, options?: AbortOptions ) => AsyncIterable<QueryEvent>
+    findProvs: (cid: CID, options?: AbortOptions) => AsyncIterable<QueryEvent>
     provide: (cid: CID, options?: DHTProvideOptions) => AsyncIterable<QueryEvent>
     put: (key: string | Uint8Array, value: Uint8Array, options?: AbortOptions) => AsyncIterable<QueryEvent>
     get: (key: string | Uint8Array, options?: AbortOptions) => AsyncIterable<QueryEvent>


### PR DESCRIPTION
`@libp2p/components` is a choke-point for our dependency graph as it depends on every interface, meaning when one interface revs a major `@libp2p/components` major has to change too which means every module depending on it also needs a major.

Switch instead to constructor injection of simple objects that let modules declare their dependencies on interfaces directly instead of indirectly via `@libp2p/components`

Refs https://github.com/libp2p/js-libp2p-components/issues/6

BREAKING CHANGE: modules no longer implement `Initializable` instead switching to constructor injection