### PR TITLE
refactor: remove use of timeout-abort-controller

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,6 @@
     "ipfs-http-client": "^60.0.0",
     "ipfsd-ctl": "^13.0.0",
     "it-all": "^2.0.0",
-    "timeout-abort-controller": "^3.0.0",
     "uint8arrays": "^4.0.2",
     "wherearewe": "^2.0.1"
   },

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -16,7 +16,6 @@ import type { PeerId } from '@libp2p/interface-peer-id'
 import type { IDResult } from 'ipfs-core-types/src/root'
 import type { PeerInfo } from '@libp2p/interface-peer-info'
 import { stop } from '@libp2p/interfaces/startable'
-import { TimeoutController } from 'timeout-abort-controller'
 import type { AbortOptions } from '@libp2p/interfaces'
 import { peerIdFromString } from '@libp2p/peer-id'
 
@@ -179,13 +178,11 @@ describe('DelegatedContentRouting', function () {
         port: opts.port,
         host: opts.host
       }))()
-      const controller = new TimeoutController(5e3)
+      const signal = AbortSignal.timeout(5e3)
 
-      const providers = await all(routing.findProviders(cid, { signal: controller.signal }))
+      const providers = await all(routing.findProviders(cid, { signal }))
 
       expect(providers.map((p) => p.id.toString())).to.include(bootstrapId.id.toString(), 'Did not include bootstrap node')
-
-      controller.clear()
     })
   })
 


### PR DESCRIPTION
related https://github.com/libp2p/js-libp2p/issues/1681